### PR TITLE
changes to narrow things up and fixed the miss on the sidedovetail us…

### DIFF
--- a/Box_Creator_Ver_dev.html
+++ b/Box_Creator_Ver_dev.html
@@ -39,11 +39,11 @@
           </div>
           <div class="field-row">
             <label for="DepthField">Depth:</label>
-            <input type="email" id="DepthField" placeholder="Depth of Box" />
+            <input type="text" id="DepthField" placeholder="Depth of Box" />
           </div>
           <div class="field-row">
             <label for="HeightField">Height:</label>
-            <input type="email" id="HeightField" placeholder="Height of Box" />
+            <input type="text" id="HeightField" placeholder="Height of Box" />
           </div>
         </div>
       </div>
@@ -58,16 +58,16 @@
           </div>
           <div class="field-row">
             <label for="SideTabWidthField">Side Joint Width:</label>
-            <input type="email" id="SideTabWidthField" placeholder="Width of Joint" />
+            <input type="text" id="SideTabWidthField" placeholder="Width of Joint" />
           </div>
           <div id="showHideTopBottomJoints" style="display:none;">
             <div class="field-row">
               <label for="BottomTabWidthField">Bottom Joint Width:</label>
-              <input type="email" id="BottomTabWidthField" placeholder="Width of Bottom Joint" />
+              <input type="text" id="BottomTabWidthField" placeholder="Width of Bottom Joint" />
             </div>
             <div class="field-row" id="showHideLidJointWidth">
               <label for="TopTabWidthField">Lid Joint Width:</label>
-              <input type="email" id="TopTabWidthField" placeholder="Width of Lid Joint" />
+              <input type="text" id="TopTabWidthField" placeholder="Width of Lid Joint" />
             </div>
           </div>
         </div>
@@ -79,11 +79,11 @@
           <div class="sub-panel-title">Machining</div>
           <div class="field-row">
             <label for="AllowanceField">Allowance:</label>
-            <input type="email" id="AllowanceField" placeholder="Allowance" />
+            <input type="text" id="AllowanceField" placeholder="Allowance" />
           </div>
           <div class="field-row">
             <label for="EdgeField">Clamping Margin:</label>
-            <input type="email" id="EdgeField" placeholder="Clamping Margin" />
+            <input type="text" id="EdgeField" placeholder="Clamping Margin" />
           </div>
         </div>
       </div>

--- a/Box_Creator_Ver_dev.html
+++ b/Box_Creator_Ver_dev.html
@@ -20,7 +20,7 @@
       <p>This Gadget Creates <u>Two Sets</u> of Vectors for <u>Each Box Part</u> on <u>Two Separate Layers (Box and CutOut)</u>. The <u>First (Box Layer) Vector</u> Shows the <u>Box Part Shape</u>. The <u>Second (CutOut Layer) Vector</u> Shows &amp; is the <u>Actual Toolpath</u> Set to <u>ON</u> the Vector.</p>
       <p>The <u>Datum</u> is located in the <u>Lower Left</u> Hand Corner.</p>
       <p>The <u>Dovetail Toolpath</u> is a Gadget Created Toolpath which cannot be <u>Re-Calculated</u> if Vectors have been moved.</p>
-      <p><u>Users Who</u> are <u>Familiar with the Gadget</u> can <u>Un-Check</u> the <u>Show Dovetail Re-Calculation Warning</u> for <u>Better Productivity</u>.</p>
+      <p><u>Users Who</u> are <u>Familiar with the Gadget</u> can <u>Un-Check</u> the <u>Show Dovetail Re-Calc Warning</u> for <u>Better Productivity</u>.</p>
     </div>
   </div>
 
@@ -111,7 +111,7 @@
     <div class="tool-bar-right">
       <label class="no-toolpath-label">
         <input type="checkbox" class="LuaButton" name="NoToolpath" id="NoToolpath" value="" />
-        No Toolpath (create vectors only)
+        No toolpath (create vectors only)
       </label>
     </div>
   </div>
@@ -173,15 +173,15 @@
     <div class="footer-options">
       <div class="footer-options-col">
         <div class="footer-option-item">
-          <label><input type="checkbox" class="LuaButton" id="WarnDovetail" />Show Dovetail Re-Calculation Warning</label>
+          <label><input type="checkbox" class="LuaButton" id="WarnDovetail" />Show dovetail re-calc warning</label>
         </div>
         <div class="footer-option-item">
-          <label><input type="checkbox" class="LuaButton" id="DarkMode" onclick="onDarkModeChanged(this)" />Enable Dark Mode</label>
+          <label><input type="checkbox" class="LuaButton" id="DarkMode" onclick="onDarkModeChanged(this)" />Enable dark mode</label>
         </div>
       </div>
       <div class="footer-options-col">
         <div class="footer-option-item">
-          <label><input type="checkbox" class="LuaButton" id="LabelFaces" />Label face vectors</label>
+          <label><input type="checkbox" class="LuaButton" id="LabelFaces" />Label face names</label>
         </div>
       </div>
     </div>

--- a/Box_Creator_Ver_dev.html
+++ b/Box_Creator_Ver_dev.html
@@ -19,8 +19,7 @@
     <div class="header-text">
       <p>This Gadget Creates <u>Two Sets</u> of Vectors for <u>Each Box Part</u> on <u>Two Separate Layers (Box and CutOut)</u>. The <u>First (Box Layer) Vector</u> Shows the <u>Box Part Shape</u>. The <u>Second (CutOut Layer) Vector</u> Shows &amp; is the <u>Actual Toolpath</u> Set to <u>ON</u> the Vector.</p>
       <p>The <u>Datum</u> is located in the <u>Lower Left</u> Hand Corner.</p>
-      <p>The <u>Dovetail Toolpath</u> is a Gadget Created Toolpath which cannot be <u>Re-Calculated</u> if Vectors have been moved.</p>
-      <p><u>Users Who</u> are <u>Familiar with the Gadget</u> can <u>Un-Check</u> the <u>Show Dovetail Re-Calc Warning</u> for <u>Better Productivity</u>.</p>
+      <p>The <u>Dovetail Toolpath</u> is a Gadget Created Toolpath which cannot be <u>Re-Calculated</u> if Vectors have been moved. <u>Users Who</u> are <u>Familiar with the Gadget</u> can <u>Un-Check</u> the <u>Show Dovetail Re-Calc Warning</u> for <u>Better Productivity</u>.</p>
     </div>
   </div>
 

--- a/Box_Creator_Ver_dev.lua
+++ b/Box_Creator_Ver_dev.lua
@@ -34,8 +34,8 @@
 g_version = "dev"                                                    -- Changed by Gremlin
 g_subVersion = "development"                                         -- Added by Gremlin
 g_title = "Box Creator"
-g_width = 840
-g_height = 900                                                    -- Changed by Sharkcutup
+g_width = 865
+g_height = 890                                                    -- Changed by Sharkcutup
 g_html_file = "Box_Creator_Ver_" .. g_version .. ".html"             -- Changed by Gremlin
 
 -- ---------- VALIDATION HELPERS ----------

--- a/Box_Creator_Ver_dev.lua
+++ b/Box_Creator_Ver_dev.lua
@@ -34,7 +34,7 @@
 g_version = "dev"                                                    -- Changed by Gremlin
 g_subVersion = "development"                                         -- Added by Gremlin
 g_title = "Box Creator"
-g_width = 1020
+g_width = 840
 g_height = 900                                                    -- Changed by Sharkcutup
 g_html_file = "Box_Creator_Ver_" .. g_version .. ".html"             -- Changed by Gremlin
 

--- a/Box_Creator_Ver_dev.lua
+++ b/Box_Creator_Ver_dev.lua
@@ -2371,12 +2371,12 @@ function ReadOptions(dialog, options, sidedovetail, bottomdovetail, topdovetail)
     local calculated_min = effective_dia
 
     if calculated_min and calculated_min > 0 then
-      local current_width = options.sidetabwidth or dovetail.min_width
+      local current_width = options.sidetabwidth or sidedovetail.min_width
       local new_width     = math.max(current_width, calculated_min)
 
       if new_width ~= current_width then
         options.sidetabwidth   = new_width
-        dovetail.min_width = new_width
+        sidedovetail.min_width = new_width
 
         -- Push it back into the dialog so user sees the update
         if dialog.SetDoubleField ~= nil then

--- a/stylesheets/layout-css-8.css
+++ b/stylesheets/layout-css-8.css
@@ -14,7 +14,7 @@ body {
 }
 
 #page-wrapper {
-  width: 940px;
+  width: 800px;
   margin: 0 auto;
   padding: 10px;
 }
@@ -62,19 +62,19 @@ body {
 /* ── Header banner ────────────────────────────────────────────────── */
 .header-image {
   float: left;
-  width: 200px;
+  width: 170px;
   background-color: #f2f4f8;
   border-right: 1px solid #d0d4de;
   padding: 10px;
   text-align: center;
 }
 .header-image img {
-  max-width: 200px;
+  max-width: 170px;
   height: auto;
 }
 .header-text {
   float: left;
-  width: 658px;
+  width: 558px;
   padding: 10px 14px;
 }
 .header-text p {
@@ -95,13 +95,13 @@ body {
 /* ── Geometry columns ─────────────────────────────────────────────── */
 .geometry-column {
   float: left;
-  width: 295px;
+  width: 245px;
   margin-right: 10px;
   margin-bottom: 10px;
 }
 .geometry-column-last {
   float: left;
-  width: 295px;
+  width: 245px;
   margin-bottom: 10px;
 }
 
@@ -168,12 +168,12 @@ body {
 }
 .tool-bar-left {
   float: left;
-  width: 580px;
+  width: 490px;
   line-height: 26px;
 }
 .tool-bar-right {
   float: left;
-  width: 320px;
+  width: 225px;
   line-height: 26px;
   font-size: 12px;
   color: #6b7280;
@@ -209,12 +209,12 @@ input.ToolPicker {
 /* ── Joint type / Lid type side-by-side panels ────────────────────── */
 .type-column {
   float: left;
-  width: 460px;
+  width: 375px;
   margin-right: 10px;
 }
 .type-column-last {
   float: left;
-  width: 460px;
+  width: 375px;
 }
 .type-panel {
   background-color: #ffffff;
@@ -239,7 +239,7 @@ input.ToolPicker {
 }
 .type-option-radio {
   float: left;
-  width: 200px;
+  width: 170px;
   padding-top: 8px;
   font-size: 12px;
   font-weight: bold;
@@ -265,17 +265,18 @@ input.ToolPicker {
 }
 .footer-ok-button {
   float: left;
-  margin-right: 14px;
+  width: 195px;
   padding-top: 8px;
+  text-align: center;
 }
 .footer-options {
   float: left;
   padding-top: 4px;
-  width: 560px;
+  width: 390px;
 }
 .footer-options-col {
   float: left;
-  width: 270px;
+  width: 195px;
 }
 .footer-option-item {
   font-size: 12px;
@@ -286,8 +287,10 @@ input.ToolPicker {
   margin-right: 4px;
 }
 .footer-cancel-button {
-  float: right;
+  float: left;
+  width: 195px;
   padding-top: 8px;
+  text-align: center;
 }
 
 /* ── OK / Cancel buttons ──────────────────────────────────────────── */

--- a/stylesheets/layout-css-8.css
+++ b/stylesheets/layout-css-8.css
@@ -209,12 +209,12 @@ input.ToolPicker {
 /* ── Joint type / Lid type side-by-side panels ────────────────────── */
 .type-column {
   float: left;
-  width: 375px;
+  width: 395px;
   margin-right: 10px;
 }
 .type-column-last {
   float: left;
-  width: 375px;
+  width: 395px;
 }
 .type-panel {
   background-color: #ffffff;


### PR DESCRIPTION
This an attempt to get the codefixes from Sharkcutup's changes along with adding in some changes to the HTML to narrow up the dialog making it a little smaller overall on the screen. 

This is what it looks like on a standard res screen

<img width="1981" height="1212" alt="image" src="https://github.com/user-attachments/assets/b2b57c4a-08fb-4213-898e-cb58a36663d4" />



